### PR TITLE
Support system-installed snowball/libstemmer if present

### DIFF
--- a/ext/mittens/ext.c
+++ b/ext/mittens/ext.c
@@ -1,4 +1,9 @@
+#ifdef USE_SYSTEM_LIBSTEMMER
+#include <libstemmer.h>
+#else
 #include "libstemmer.h"
+#endif
+
 #include "ruby/ruby.h"
 
 typedef struct stemmer {

--- a/ext/mittens/extconf.rb
+++ b/ext/mittens/extconf.rb
@@ -1,14 +1,20 @@
 require "mkmf"
 require "open3"
 
-vendor = File.expand_path("../../vendor/snowball", __dir__)
-# CFLAGS from vendor/snowball/GNUmakefile and -fPIC
-cflags = "-O2 -W -Wall -Wmissing-prototypes -Wmissing-declarations -fPIC"
-output, status = Open3.capture2("make", "CFLAGS=#{cflags}", chdir: vendor)
-puts output
-raise "Command failed" unless status.success?
+if have_library('stemmer', 'sb_stemmer_new')
+  $CFLAGS += " -DUSE_SYSTEM_LIBSTEMMER"
+else
+  $stderr.puts "System libstemmer not found, using bundled version"
 
-$INCFLAGS += " -I$(srcdir)/../../vendor/snowball/include"
-$LDFLAGS += " $(srcdir)/../../vendor/snowball/libstemmer.a"
+  vendor = File.expand_path("../../vendor/snowball", __dir__)
+  # CFLAGS from vendor/snowball/GNUmakefile and -fPIC
+  cflags = "-O2 -W -Wall -Wmissing-prototypes -Wmissing-declarations -fPIC"
+  output, status = Open3.capture2("make", "CFLAGS=#{cflags}", chdir: vendor)
+  puts output
+  raise "Command failed" unless status.success?
+
+  $INCFLAGS += " -I$(srcdir)/../../vendor/snowball/include"
+  $LDFLAGS += " $(srcdir)/../../vendor/snowball/libstemmer.a"
+end
 
 create_makefile("mittens/ext")


### PR DESCRIPTION
I had some trouble compiling the copy of libstemmer included in this repo when installing with nix, so I made this change and added this to my flake.nix to use the one from nixpkgs:

```nix
gemConfig = {
  mittens = attrs: {
    buildInputs = [ pkgs.libstemmer ];
  };
};
```

It might be preferable to pass in a path to the library instead, but this worked for my use case at least.