### PR TITLE
Build on BSDs

### DIFF
--- a/ext/mittens/extconf.rb
+++ b/ext/mittens/extconf.rb
@@ -4,7 +4,14 @@ require "open3"
 vendor = File.expand_path("../../vendor/snowball", __dir__)
 # CFLAGS from vendor/snowball/GNUmakefile and -fPIC
 cflags = "-O2 -W -Wall -Wmissing-prototypes -Wmissing-declarations -fPIC"
-output, status = Open3.capture2("make", "CFLAGS=#{cflags}", chdir: vendor)
+
+make_cmd = "make"
+if RbConfig::CONFIG["host_os"] =~ /bsd|dragonfly/i
+  gmake = find_executable("gmake")
+  make_cmd = gmake if gmake
+end
+
+output, status = Open3.capture2(make_cmd, "CFLAGS=#{cflags}", chdir: vendor)
 puts output
 raise "Command failed" unless status.success?
 


### PR DESCRIPTION
The current to build the native extension for snowball relies on make being GNU make which is not the case on BSDs like FreeBSD. This change looks for the "gmake" binary instead to call it to build the extension.

Test on FreeBSD 14.3.

Previously:
```
$ bundle exec rake build
mittens 0.3.0 built to pkg/mittens-0.3.0.gem.
$ gem install pkg/*.gem
Building native extensions. This could take a while...
ERROR:  Error installing pkg/mittens-0.3.0.gem:
        ERROR: Failed to build gem native extension.

    current directory: /home/robin/.local/share/mise/installs/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/mittens-0.3.0/ext/mittens
/home/robin/.local/share/mise/installs/ruby/3.4.7/bin/ruby extconf.rb
make: no target to make.
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include=${opt-dir}/include
        --without-opt-include
        --with-opt-lib=${opt-dir}/lib
        --without-opt-lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/home/robin/.local/share/mise/installs/ruby/3.4.7/bin/$(RUBY_BASE_NAME)
extconf.rb:9:in '<main>': Command failed (RuntimeError)

make: stopped in /home/robin/.local/share/mise/installs/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/mittens-0.3.0/vendor/snowball

extconf failed, exit code 1

Gem files will remain installed in /home/robin/.local/share/mise/installs/ruby/3.4.7/lib/ruby/gems/3.4.0/gems/mittens-0.3.0 for inspection.
Results logged to /home/robin/.local/share/mise/installs/ruby/3.4.7/lib/ruby/gems/3.4.0/extensions/x86_64-freebsd-14/3.4.0/mittens-0.3.0/gem_make.out
```

Now:
```
$ bundle exec rake build
mittens 0.3.0 built to pkg/mittens-0.3.0.gem.
$r gem install pkg/*.gem
Building native extensions. This could take a while...
Successfully installed mittens-0.3.0
Parsing documentation for mittens-0.3.0
Installing ri documentation for mittens-0.3.0
Done installing documentation for mittens after 0 seconds
1 gem installed
```

I took the liberty to prepare a version bump but happy to drop the commit if you prefer to do it differently.